### PR TITLE
Add netlify.toml for Netlify deploy config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish="dist"
+  base = "my-app"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
This configuration is necessary because Netlify expect different defaults:

```toml
[build]
  command = "npm run build"
  publish="dist"
  base = "my-app"
```

This says that the app is not in the root of the repo but in the `my-app`
folder. Then it says the build output is in the `my-app/dist` folder
and to build the project using `npm run build` command.

```
[[redirects]]
  from = "/*"
  to = "/index.html"
  status = 200
```

This fixes potential issues with Router component.
                                                                      `